### PR TITLE
Serialize many TAKE_SNAPSHOT reads

### DIFF
--- a/include/zhpe_zmmu.h
+++ b/include/zhpe_zmmu.h
@@ -38,6 +38,8 @@
 #define _ZHPE_ZMMU_H_
 
 extern uint zhpe_no_avx;
+extern uint snap_tries;
+extern uint snap_dbg_obs;
 
 #define ROUND_DOWN_PAGE(_addr, _sz) ((_addr) & -(_sz))
 #define ROUND_UP_PAGE(_addr, _sz)   (((_addr) + ((_sz) - 1)) & -(_sz))


### PR DESCRIPTION
Also bail after snap_tries attempts, and optionally
disable the HW dbg_obs on failure.

Signed-off-by: Jim Hull <jim.hull@hpe.com>