### PR TITLE
Fix zhpe_release_owned_xdm_queues locking issue

### DIFF
--- a/include/zhpe_driver.h
+++ b/include/zhpe_driver.h
@@ -518,7 +518,7 @@ struct file_data {
     union zpages        *local_shared_zpage;
     struct zmap         *local_shared_zmap;
     struct zmap         *global_shared_zmap;
-    spinlock_t          xdm_queue_lock;
+    struct mutex        xdm_queue_mutex;
     DECLARE_BITMAP(xdm_queues, MAX_XDM_QUEUES_PER_SLICE*SLICES);
     spinlock_t          rdm_queue_lock;
     DECLARE_BITMAP(rdm_queues, MAX_RDM_QUEUES_PER_SLICE*SLICES);

--- a/zhpe_core.c
+++ b/zhpe_core.c
@@ -1782,7 +1782,7 @@ static int zhpe_open(struct inode *inode, struct file *file)
     fdata->fd_rmr_tree = RB_ROOT;
     INIT_LIST_HEAD(&fdata->zmap_list);
     spin_lock_init(&fdata->zmap_lock);
-    spin_lock_init(&fdata->xdm_queue_lock);
+    mutex_init(&fdata->xdm_queue_mutex);
     /* xdm_queues tracks what queues are owned by this file_data */
     /* Revisit Perf: what is the tradeoff of size of bitmap vs. rbtree? */
     bitmap_zero(fdata->xdm_queues, zhpe_xdm_queues_per_slice*SLICES);


### PR DESCRIPTION
Because xdm_wait_for_active_clear() can sleep while holding xdm_queue_lock,
change it to a mutex instead of a spinlock.

Signed-off-by: Jim Hull <jim.hull@hpe.com>